### PR TITLE
Add TODO metrics workflow artifacts

### DIFF
--- a/.github/workflows/todo-metrics.yml
+++ b/.github/workflows/todo-metrics.yml
@@ -1,0 +1,112 @@
+name: TODO Metrics
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  todo-metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Count TODOs in current revision
+        run: |
+          mkdir -p .tmp/todo-metrics
+          python scripts/todo_metrics.py count --output .tmp/todo-metrics/current.json
+          python scripts/todo_metrics.py badge --input .tmp/todo-metrics/current.json --output .tmp/todo-metrics/todo-badge.svg
+
+      - name: Count TODOs at merge base
+        if: github.event_name == 'pull_request'
+        id: merge_base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          git fetch origin "${BASE_REF}" --depth=1
+          merge_base="$(git merge-base HEAD "origin/${BASE_REF}")"
+          echo "merge_base=${merge_base}" >> "$GITHUB_OUTPUT"
+          python scripts/todo_metrics.py count --rev "${merge_base}" --output .tmp/todo-metrics/base.json
+
+      - name: Comment TODO delta on pull request
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          BASE_JSON: .tmp/todo-metrics/base.json
+          CURRENT_JSON: .tmp/todo-metrics/current.json
+          MERGE_BASE: ${{ steps.merge_base.outputs.merge_base }}
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- todo-metrics-comment -->";
+            const base = JSON.parse(fs.readFileSync(process.env.BASE_JSON, "utf8"));
+            const current = JSON.parse(fs.readFileSync(process.env.CURRENT_JSON, "utf8"));
+            const delta = current.count - base.count;
+            const deltaLabel = delta > 0 ? `+${delta}` : `${delta}`;
+            const body = [
+              marker,
+              "## TODO metrics",
+              "",
+              `- Base (${process.env.MERGE_BASE.slice(0, 7)}): ${base.count}`,
+              `- Head (${current.reference.slice(0, 7)}): ${current.count}`,
+              `- Delta: ${deltaLabel}`,
+            ].join("\n");
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.user.type === "Bot" && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - name: Upload TODO count artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: todo-count.json
+          path: .tmp/todo-metrics/current.json
+          archive: false
+          retention-days: 30
+
+      - name: Upload TODO badge artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v7
+        with:
+          name: todo-badge.svg
+          path: .tmp/todo-metrics/todo-badge.svg
+          archive: false
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Here is my playground
+
+This repository includes an experimental GitHub Actions workflow that counts `TODO`
+comments in source files, compares the count against the pull request merge base,
+and uploads the current main-branch count together with a badge SVG as artifacts.

--- a/scripts/todo_metrics.py
+++ b/scripts/todo_metrics.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SOURCE_SUFFIXES = {
+    ".c",
+    ".cc",
+    ".cpp",
+    ".css",
+    ".go",
+    ".h",
+    ".hpp",
+    ".html",
+    ".java",
+    ".js",
+    ".json",
+    ".jsx",
+    ".mjs",
+    ".py",
+    ".rb",
+    ".rs",
+    ".sh",
+    ".sql",
+    ".swift",
+    ".toml",
+    ".ts",
+    ".tsx",
+    ".yaml",
+    ".yml",
+}
+SOURCE_FILENAMES = {
+    "Dockerfile",
+    "Justfile",
+    "justfile",
+    "Makefile",
+}
+EXCLUDED_PARTS = {
+    ".git",
+    ".github",
+    ".tmp",
+    "coverage",
+    "dist",
+    "docs",
+    "node_modules",
+    "target",
+}
+COMMENT_MARKERS = ("//", "#", "/*", "*", "<!--", "--")
+
+
+def run_git(args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], text=True)
+
+
+def list_files(revision: str | None) -> list[str]:
+    if revision:
+        output = run_git(["ls-tree", "-r", "--name-only", revision])
+        return [line for line in output.splitlines() if line]
+    output = subprocess.check_output(
+        ["git", "ls-files", "--cached", "--others", "--exclude-standard", "-z"]
+    )
+    return [path.decode("utf-8") for path in output.split(b"\0") if path]
+
+
+def is_source_file(path_str: str) -> bool:
+    path = Path(path_str)
+    if any(part in EXCLUDED_PARTS for part in path.parts):
+        return False
+    if path.name.startswith(".tmp"):
+        return False
+    if path.name in SOURCE_FILENAMES:
+        return True
+    return path.suffix.lower() in SOURCE_SUFFIXES
+
+
+def is_todo_comment(line: str) -> bool:
+    for marker in COMMENT_MARKERS:
+        index = line.find(marker)
+        if index < 0:
+            continue
+        prefix = line[:index]
+        if any(quote in prefix for quote in ('"', "'", "`")):
+            continue
+        comment = line[index + len(marker) :].lstrip()
+        if comment.startswith("TODO"):
+            return True
+    return False
+
+
+def read_file(path: str, revision: str | None) -> str:
+    if revision:
+        return run_git(["show", f"{revision}:{path}"])
+    return Path(path).read_text(encoding="utf-8")
+
+
+def count_todos(revision: str | None) -> dict[str, object]:
+    matches: list[dict[str, object]] = []
+    for path in sorted(list_files(revision)):
+        if not is_source_file(path):
+            continue
+        try:
+            content = read_file(path, revision)
+        except (OSError, subprocess.CalledProcessError, UnicodeDecodeError):
+            continue
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            if is_todo_comment(line):
+                matches.append(
+                    {
+                        "path": path,
+                        "line": line_number,
+                        "text": line.strip(),
+                    }
+                )
+    reference = revision or run_git(["rev-parse", "HEAD"]).strip()
+    return {
+        "count": len(matches),
+        "reference": reference,
+        "matches": matches,
+    }
+
+
+def render_badge(label: str, count: int) -> str:
+    count_text = str(count)
+    left_width = 62
+    right_width = max(34, 10 + len(count_text) * 8)
+    total_width = left_width + right_width
+    right_x = left_width + right_width / 2
+    color = "#2ea44f" if count == 0 else "#dbab09" if count < 5 else "#cf222e"
+    return f"""<svg xmlns="http://www.w3.org/2000/svg" width="{total_width}" height="20" role="img" aria-label="{label}: {count_text}">
+<title>{label}: {count_text}</title>
+<linearGradient id="smooth" x2="0" y2="100%">
+<stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+<stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
+<stop offset=".9" stop-opacity=".3"/>
+<stop offset="1" stop-opacity=".5"/>
+</linearGradient>
+<clipPath id="round">
+<rect width="{total_width}" height="20" rx="3" fill="#fff"/>
+</clipPath>
+<g clip-path="url(#round)">
+<rect width="{left_width}" height="20" fill="#555"/>
+<rect x="{left_width}" width="{right_width}" height="20" fill="{color}"/>
+<rect width="{total_width}" height="20" fill="url(#smooth)"/>
+</g>
+<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
+<text x="{left_width / 2}" y="15" fill="#010101" fill-opacity=".3">{label}</text>
+<text x="{left_width / 2}" y="14">{label}</text>
+<text x="{right_x}" y="15" fill="#010101" fill-opacity=".3">{count_text}</text>
+<text x="{right_x}" y="14">{count_text}</text>
+</g>
+</svg>
+"""
+
+
+def command_count(args: argparse.Namespace) -> int:
+    metrics = count_todos(args.rev)
+    output = json.dumps(metrics, indent=2)
+    if args.output:
+        Path(args.output).write_text(output + "\n", encoding="utf-8")
+    else:
+        print(output)
+    return 0
+
+
+def command_badge(args: argparse.Namespace) -> int:
+    metrics = json.loads(Path(args.input).read_text(encoding="utf-8"))
+    svg = render_badge("TODOs", int(metrics["count"]))
+    Path(args.output).write_text(svg, encoding="utf-8")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate TODO metrics.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    count_parser = subparsers.add_parser("count", help="Count TODOs in source files.")
+    count_parser.add_argument("--rev", help="Git revision to inspect.")
+    count_parser.add_argument("--output", help="Path to write the metrics JSON.")
+    count_parser.set_defaults(func=command_count)
+
+    badge_parser = subparsers.add_parser("badge", help="Render a badge SVG from metrics JSON.")
+    badge_parser.add_argument("--input", required=True, help="Metrics JSON file.")
+    badge_parser.add_argument("--output", required=True, help="Badge SVG output path.")
+    badge_parser.set_defaults(func=command_badge)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,4 @@
+export function plannedGreeting(name) {
+  // TODO: Replace this placeholder once a real example is added.
+  return `Hello, ${name}!`;
+}


### PR DESCRIPTION
## Summary
- add a workflow that counts TODO comments on pull requests and main pushes
- compare the current branch against the merge base and post the delta to the pull request
- upload the main-branch TODO count JSON and badge SVG as non-zipped artifacts

## Testing
- python3 -m py_compile scripts/todo_metrics.py
- python3 scripts/todo_metrics.py count --rev HEAD
- python3 scripts/todo_metrics.py count --rev origin/main