### PR TITLE
Clean the orphan asset branch before publishing

### DIFF
--- a/.github/workflows/todo-metrics.yml
+++ b/.github/workflows/todo-metrics.yml
@@ -127,6 +127,7 @@ jobs:
             git worktree add --detach .tmp/badge-assets-worktree
             cd .tmp/badge-assets-worktree
             git checkout --orphan "${ASSET_BRANCH}"
+            git rm -rf --ignore-unmatch .
             find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
             cd -
           fi


### PR DESCRIPTION
## Summary
- clear the orphan branch index before publishing generated badge assets
- keep badge-assets limited to current.json and todo-badge.svg on first publish

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/todo-metrics.yml")'