### PR TITLE
Replace the badge asset tree on each publish

### DIFF
--- a/.github/workflows/todo-metrics.yml
+++ b/.github/workflows/todo-metrics.yml
@@ -127,10 +127,13 @@ jobs:
             git worktree add --detach .tmp/badge-assets-worktree
             cd .tmp/badge-assets-worktree
             git checkout --orphan "${ASSET_BRANCH}"
-            git rm -rf --ignore-unmatch .
-            find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
             cd -
           fi
+
+          cd .tmp/badge-assets-worktree
+          git rm -rf --ignore-unmatch .
+          find . -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cd -
 
           cp .tmp/badge-assets/current.json .tmp/badge-assets-worktree/current.json
           cp .tmp/badge-assets/todo-badge.svg .tmp/badge-assets-worktree/todo-badge.svg


### PR DESCRIPTION
## Summary
- clear the badge-assets worktree before copying generated files on every publish
- ensure the dedicated asset branch only keeps current.json and todo-badge.svg

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/todo-metrics.yml")'