### PR TITLE
Add the TODO badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Here is my playground
 
+![TODO badge](https://raw.githubusercontent.com/kitsuyui/playground/badge-assets/todo-badge.svg)
+
 This repository includes an experimental GitHub Actions workflow that counts `TODO`
 comments in source files, compares the count against the pull request merge base,
-and uploads the current main-branch count together with a badge SVG as artifacts.
+publishes the current main-branch count and badge SVG to the `badge-assets`
+branch, and also uploads the generated files as workflow artifacts.


### PR DESCRIPTION
## Summary
- add the generated TODO badge to the README
- update the workflow description to mention the badge-assets branch

## Testing
- rendered the README badge URL against the published badge-assets branch