### PR TITLE
fix: rename plannedGreeting to greeting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-export function plannedGreeting(name) {
-  // TODO: Replace this placeholder once a real example is added.
+export function greeting(name) {
   if (typeof name !== 'string') {
     throw new TypeError(`name must be a string, got ${typeof name}`);
   }


### PR DESCRIPTION
## Summary

Rename `plannedGreeting` to `greeting` in `src/index.js` and remove the misleading "TODO: Replace this placeholder" comment.

The function works correctly — it takes a `name` argument and returns `Hello, ${name}!`. The `planned` prefix and TODO comment both imply the function is unfinished, which misleads readers about its current status.

## Changes

- `src/index.js`: rename `plannedGreeting` → `greeting`, remove placeholder TODO comment

## ⚠️ Breaking Change Notice

This is a **breaking API rename**. Any code importing `plannedGreeting` from this module will need to update its import to `greeting`.

Collateral check triggered `breaking-suspect` on the PR title. Given this is a playground repo ("a small playground for trying ideas quickly") with the function explicitly marked as a placeholder, the actual user impact is assessed as minimal — but human review is required before merge.

## Verification

- Collateral check: `breaking-suspect` advisory (see above)
- No test suite present in this repo
