### PR TITLE
fix: guard against non-string name in plannedGreeting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 export function plannedGreeting(name) {
   // TODO: Replace this placeholder once a real example is added.
+  if (typeof name !== 'string') {
+    throw new TypeError(`name must be a string, got ${typeof name}`);
+  }
   return `Hello, ${name}!`;
 }


### PR DESCRIPTION
## Problem

`plannedGreeting(name)` uses a template literal to format the output, which
silently coerces any value via JavaScript's implicit `.toString()`:

- `plannedGreeting(null)` → `"Hello, null\!"`
- `plannedGreeting(undefined)` → `"Hello, undefined\!"`
- `plannedGreeting({})` → `"Hello, [object Object]\!"`

The caller receives a semantically incorrect greeting with no error.

## Change

Add an explicit `typeof` guard before the return:

```js
if (typeof name \!== 'string') {
  throw new TypeError(`name must be a string, got ${typeof name}`);
}
```

Non-string inputs now fail fast with a clear error rather than producing
silent garbage output.

## Verification

- Collateral check: clean (no `gha-inline-script`, `version-shrink`, or `too-many-files`)