### PR TITLE
fix: reject empty string name in plannedGreeting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,8 @@ export function plannedGreeting(name) {
   if (typeof name !== 'string') {
     throw new TypeError(`name must be a string, got ${typeof name}`);
   }
+  if (name === '') {
+    throw new RangeError('name must not be empty');
+  }
   return `Hello, ${name}!`;
 }


### PR DESCRIPTION
## Problem

`plannedGreeting(name)` has no boundary check for the `name` parameter. Passing an empty string `""` returns `"Hello, !"` — a semantically incomplete greeting with no error, making it impossible for callers to distinguish between valid and invalid input.

## Change

Add an explicit empty-string guard before the template literal:

```js
if (name === '') {
  throw new RangeError('name must not be empty');
}
```

Callers now receive a clear `RangeError` when they pass an empty string, rather than silent garbage output.

## Scope

This fix targets the empty-string boundary condition specifically identified as the most concrete defect. Non-string type coercion (`null`, `undefined`, objects) is addressed by a separate open PR. Length and multi-byte character checks are out of scope for this surface-level fix.

## Verification

- JavaScript syntax verified: no parse errors
- No test suite present in repo (playground placeholder)
